### PR TITLE
fix: correct best_instance_index in batch.select_instance

### DIFF
--- a/modAL/batch.py
+++ b/modAL/batch.py
@@ -101,7 +101,10 @@ def select_instance(
     scores = alpha * (1 - similarity_scores) + (1 - alpha) * X_uncertainty[mask]
 
     # Isolate and return our best instance for labeling as the one with the largest score.
-    best_instance_index = np.argmax(scores)
+    best_instance_index_in_unlabeled = np.argmax(scores)
+    n_pool, _ = X_pool.shape
+    unlabeled_indices = [i for i in range(n_pool) if mask[i]]
+    best_instance_index = unlabeled_indices[best_instance_index_in_unlabeled]
     mask[best_instance_index] = 0
     return best_instance_index, X_pool[best_instance_index].reshape(1, -1), mask
 


### PR DESCRIPTION
https://github.com/modAL-python/modAL/blob/452898fc181b6d4ae6399dfdcb311ceb952c8486/modAL/batch.py#L104-L106

Hi!

This pull request addresses the bug that the computed `best_instance_index` in batch.select_instance is the index of the best instance in `X_pool[mask]` instead of the index in `X_pool`.

For this reason, the returned `X_pool[best_instance_index].reshape(1, -1)` and `mask` (updated with `mask[best_instance_index] = 0`) are both incorrect.


