### PR TITLE
fix: selection.shuffled_argmax and its test case fixed

### DIFF
--- a/modAL/utils/selection.py
+++ b/modAL/utils/selection.py
@@ -22,6 +22,7 @@ def shuffled_argmax(values: np.ndarray, n_instances: int = 1) -> np.ndarray:
     Returns:
         The indices of the n_instances largest values.
     """
+    assert n_instances <= values.shape[0], 'n_instances must be less or equal than the size of utility'
 
     # shuffling indices and corresponding values
     shuffled_idx = np.random.permutation(len(values))
@@ -29,7 +30,7 @@ def shuffled_argmax(values: np.ndarray, n_instances: int = 1) -> np.ndarray:
 
     # getting the n_instances best instance
     # since mergesort is used, the shuffled order is preserved
-    sorted_query_idx = np.argsort(shuffled_values, kind='mergesort')[:n_instances]
+    sorted_query_idx = np.argsort(shuffled_values, kind='mergesort')[len(shuffled_values)-n_instances:]
 
     # inverting the shuffle
     query_idx = shuffled_idx[sorted_query_idx]

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -177,8 +177,8 @@ class TestUtils(unittest.TestCase):
         for n_pool in range(1, 100):
             for n_instances in range(1, n_pool+1):
                 values = np.random.permutation(n_pool)
-                true_query_idx = np.argsort(values)[:n_instances]
-
+                true_query_idx = np.argsort(values)[len(values)-n_instances:]
+                
                 np.testing.assert_equal(
                     true_query_idx,
                     modAL.utils.selection.shuffled_argmax(values, n_instances)


### PR DESCRIPTION
This PR fixes the bug that selection.shuffled_argmax (and corresponding test case) computes argmin instead of argmax.

This PR cannot pass the test case for shuffled_argmax when core_tests.py is run, since it imports the shuffled_argmax in a released version.