### PR TITLE
Updated doc for ActiveLearner

### DIFF
--- a/modAL/models/learners.py
+++ b/modAL/models/learners.py
@@ -36,7 +36,7 @@ class ActiveLearner(BaseLearner):
         estimator: The estimator to be used in the active learning loop.
         query_strategy: Function providing the query strategy for the active learning loop.
         X_training: If the model hasn't been fitted yet it is None, otherwise it contains the samples
-            which the model has been trained on.
+            which the model has been trained on. If provided, the method fit() of estimator is called during __init__()
         y_training: The labels corresponding to X_training.
 
     Examples:


### PR DESCRIPTION
When X_training is provided a call to the method fit was not expected. This happens in the __init__() of the BaseLearner