### PR TITLE
Now sets classes when fitting committee

### DIFF
--- a/modAL/models/learners.py
+++ b/modAL/models/learners.py
@@ -312,6 +312,22 @@ class Committee(BaseCommittee):
     def _add_training_data(self, X: modALinput, y: modALinput):
         super()._add_training_data(X, y)
 
+    def fit(self, X: modALinput, y: modALinput, **fit_kwargs) -> 'BaseCommittee':
+        """
+        Fits every learner to a subset sampled with replacement from X. Calling this method makes the learner forget the
+        data it has seen up until this point and replaces it with X! If you would like to perform bootstrapping on each
+        learner using the data it has seen, use the method .rebag()!
+
+        Calling this method makes the learner forget the data it has seen up until this point and replaces it with X!
+
+        Args:
+            X: The samples to be fitted on.
+            y: The corresponding labels.
+            **fit_kwargs: Keyword arguments to be passed to the fit method of the predictor.
+        """
+        super().fit(X, y, **fit_kwargs)
+        self._set_classes()
+
     def teach(self, X: modALinput, y: modALinput, bootstrap: bool = False, only_new: bool = False, **fit_kwargs) -> None:
         """
         Adds X and y to the known training data for each learner and retrains learners with the augmented dataset.
@@ -323,7 +339,6 @@ class Committee(BaseCommittee):
             only_new: If True, the model is retrained using only X and y, ignoring the previously provided examples.
             **fit_kwargs: Keyword arguments to be passed to the fit method of the predictor.
         """
-
         super().teach(X, y, bootstrap=bootstrap, only_new=only_new, **fit_kwargs)
         self._set_classes()
 


### PR DESCRIPTION
This pull requests aims to solve the second issue mentioned in #97. When creating a committee without any training data, calling `Committee.fit(X, y)` would cause an error because `Committee.classes_` was `None`.

The following code would cause an error in vote_entropy and other disagreement functions:

```python
import numpy as np
from sklearn.svm import SVC
from modAL.uncertainty import uncertainty_sampling
from modAL.disagreement import vote_entropy_sampling
from modAL.models import ActiveLearner, Committee

# Create data
X = np.array([[0, 0],
              [0, 1],
              [1, 0],
              [1, 1]])

y = np.array([1, 1, 0 ,0])

X_teach = X[:3]
y_teach = y[:3]

X_query = X[3].reshape((-1, 2))
y_query = y[3]

# ActiveLearner
svm = SVC(probability=True, gamma='auto')
learner = ActiveLearner(svm, uncertainty_sampling)

learner.fit(X_teach, y_teach)

query_idx, query_inst = learner.query(X_query)

print('Index %d, Coordinates %s' % (query_idx, query_inst))

# Committee
estimators = [SVC(probability=True, gamma='auto') for _ in range(20)]
learner_list = [ActiveLearner(estimator, uncertainty_sampling) for estimator in estimators]
committee = Committee(learner_list, vote_entropy_sampling)

committee.fit(X_teach, y_teach)

query_idx, query_inst = committee.query(X_query)

print('Index %d, Coordinates %s' % (query_idx, query_inst))
```

> p_vote = np.zeros(shape=(X.shape[0], len(committee.classes_)))
> TypeError: object of type 'NoneType' has no len() 

With the fix, it is able to run smoothly.