### PR TITLE
Resolve #108 - training data transformations should not be reused 

### DIFF
--- a/modAL/batch.py
+++ b/modAL/batch.py
@@ -8,7 +8,7 @@ import numpy as np
 import scipy.sparse as sp
 from sklearn.metrics.pairwise import pairwise_distances, pairwise_distances_argmin_min
 
-from modAL.utils.data import data_vstack, modALinput
+from modAL.utils.data import data_vstack, modALinput, data_shape
 from modAL.models.base import BaseCommittee, BaseLearner
 from modAL.uncertainty import classifier_uncertainty
 
@@ -150,8 +150,10 @@ def ranked_batch(classifier: Union[BaseLearner, BaseCommittee],
     if classifier.X_training is None:
         best_coldstart_instance_index, labeled = select_cold_start_instance(X=unlabeled, metric=metric, n_jobs=n_jobs)
         instance_index_ranking = [best_coldstart_instance_index]
-    elif classifier.X_training.shape[0] > 0:
-        labeled = classifier.Xt_training[:] if classifier.on_transformed else classifier.X_training[:]
+    elif data_shape(classifier.X_training)[0] > 0:
+        labeled = classifier.transform_without_estimating(
+            classifier.X_training
+        ) if classifier.on_transformed else classifier.X_training[:]
         instance_index_ranking = []
     
     # The maximum number of records to sample.

--- a/modAL/models/base.py
+++ b/modAL/models/base.py
@@ -66,11 +66,9 @@ class BaseLearner(ABC, BaseEstimator):
         self.on_transformed = on_transformed
 
         self.X_training = X_training
-        self.Xt_training = None
         self.y_training = y_training
         if X_training is not None:
             self._fit_to_known(bootstrap=bootstrap_init, **fit_kwargs)
-            self.Xt_training = self.transform_without_estimating(self.X_training) if self.on_transformed else None
 
         assert isinstance(force_all_finite, bool), 'force_all_finite must be a bool'
         self.force_all_finite = force_all_finite
@@ -92,15 +90,10 @@ class BaseLearner(ABC, BaseEstimator):
 
         if self.X_training is None:
             self.X_training = X
-            self.Xt_training = self.transform_without_estimating(self.X_training) if self.on_transformed else None
             self.y_training = y
         else:
             try:
                 self.X_training = data_vstack((self.X_training, X))
-                self.Xt_training = data_vstack((
-                    self.Xt_training,
-                    self.transform_without_estimating(X)
-                )) if self.on_transformed else None
                 self.y_training = data_vstack((self.y_training, y))
             except ValueError:
                 raise ValueError('the dimensions of the new training data and label must'
@@ -213,7 +206,6 @@ class BaseLearner(ABC, BaseEstimator):
         check_X_y(X, y, accept_sparse=True, ensure_2d=False, allow_nd=True, multi_output=True, dtype=None,
                   force_all_finite=self.force_all_finite)
         self.X_training, self.y_training = X, y
-        self.Xt_training = self.transform_without_estimating(self.X_training) if self.on_transformed else None
         return self._fit_to_known(bootstrap=bootstrap, **fit_kwargs)
 
     def predict(self, X: modALinput, **predict_kwargs) -> Any:


### PR DESCRIPTION
Fixes #108 

Transformed training data was originally stored as an optimization to not re-transform data between queries. Such an approach is faulty for all learnable transformatons, as these are changed after model retraining. The transformed training data is hence no longer stored.