### PR TITLE
Update Installation.rst

### DIFF
--- a/docs/source/content/overview/Installation.rst
+++ b/docs/source/content/overview/Installation.rst
@@ -5,7 +5,7 @@ modAL requires
    * Python >= 3.5
    * NumPy >= 1.13
    * SciPy >= 0.18
-   * scikit-learn >= 0.18
+   * scikit-learn >= 0.22
 
 You can install modAL directly with pip:
 


### PR DESCRIPTION
`modAL/models/base.py` imports `_BaseHeterogeneousEnsemble` from `sklearn.ensemble._base`. The first stable release in which the change from `sklearn.ensemble.base` to the protected `sklearn.ensemble._base` occurred appears to be `v0.22`. See https://scikit-learn.org/stable/whats_new/v0.22.html#clear-definition-of-the-public-api.