### PR TITLE
Diverse Mini-batch Active Learning

### DIFF
--- a/modAL/batch.py
+++ b/modAL/batch.py
@@ -242,6 +242,12 @@ def kmeans_batch(
     Returns:
         The indices of the top n_instances unlabelled samples.
     """
+    # Limit data set based on n_instances and filter_param
+    record_limit = filter_param * n_instances
+    keep_args = np.argsort(uncertainty_scores)[-record_limit:]
+    uncertainty_scores = uncertainty_scores[keep_args]
+    unlabeled = unlabeled[keep_args]
+
     # transform unlabeled data if needed
     if classifier.on_transformed:
         unlabeled = classifier.transform_without_estimating(unlabeled)

--- a/setup.py
+++ b/setup.py
@@ -10,5 +10,5 @@ setup(
     url='https://modAL-python.github.io/',
     packages=['modAL', 'modAL.models', 'modAL.utils'],
     classifiers=['Development Status :: 4 - Beta'],
-    install_requires=['numpy>=1.13', 'scikit-learn>=0.18', 'scipy>=0.18', 'pandas>=1.1.0'],
+    install_requires=['numpy>=1.13', 'scikit-learn>=0.20', 'scipy>=0.18', 'pandas>=1.1.0'],
 )

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -799,7 +799,8 @@ class TestActiveLearner(unittest.TestCase):
         n_samples = 10
         n_features = 5
         query_strategies = [
-            modAL.batch.uncertainty_batch_sampling
+            modAL.batch.uncertainty_batch_sampling,
+            modAL.batch.diverse_batch_kmeans,
             # add further strategies which work with instance representations
             # no further ones as of 25.09.2020
         ]
@@ -831,7 +832,8 @@ class TestActiveLearner(unittest.TestCase):
         properly for on_transformed=True query strategies.
         """
         query_strategies = [
-            modAL.batch.uncertainty_batch_sampling
+            modAL.batch.uncertainty_batch_sampling,
+            modAL.batch.diverse_batch_kmeans,
             # add further strategies which work with instance representations
             # no further ones as of 09.12.2020
         ]
@@ -1152,7 +1154,8 @@ class TestCommittee(unittest.TestCase):
         n_samples = 10
         n_features = 5
         query_strategies = [
-            modAL.batch.uncertainty_batch_sampling
+            modAL.batch.uncertainty_batch_sampling,
+            modAL.batch.diverse_batch_kmeans,
             # add further strategies which work with instance representations
             # no further ones as of 25.09.2020
         ]
@@ -1318,6 +1321,7 @@ class TestExamples(unittest.TestCase):
         import example_tests.information_density
         import example_tests.bayesian_optimization
         import example_tests.ranked_batch_mode
+        import example_tests.diverse_batch_kmeans
 
 
 if __name__ == '__main__':

--- a/tests/example_tests/diverse_batch_kmeans.py
+++ b/tests/example_tests/diverse_batch_kmeans.py
@@ -1,0 +1,79 @@
+import numpy as np
+from sklearn.datasets import load_iris
+from sklearn.decomposition import PCA
+from sklearn.neighbors import KNeighborsClassifier
+from functools import partial
+
+from modAL.batch import diverse_batch_kmeans
+from modAL.models import ActiveLearner
+
+# Set our RNG for reproducibility.
+RANDOM_STATE_SEED = 123
+np.random.seed(RANDOM_STATE_SEED)
+
+iris = load_iris()
+X_raw = iris['data']
+y_raw = iris['target']
+
+# Define our PCA transformer and fit it onto our raw dataset.
+pca = PCA(n_components=2, random_state=RANDOM_STATE_SEED)
+transformed_iris = pca.fit_transform(X=X_raw)
+
+# Isolate the data we'll need for plotting.
+x_component, y_component = transformed_iris[:, 0], transformed_iris[:, 1]
+
+# Isolate our examples for our labeled dataset.
+n_labeled_examples = X_raw.shape[0]
+training_indices = np.random.randint(low=0, high=n_labeled_examples + 1, size=3)
+
+X_train = X_raw[training_indices]
+y_train = y_raw[training_indices]
+
+# Isolate the non-training examples we'll be querying.
+X_pool = np.delete(X_raw, training_indices, axis=0)
+y_pool = np.delete(y_raw, training_indices, axis=0)
+
+# Pre-set our batch sampling to retrieve 3 samples at a time.
+BATCH_SIZE = 3
+preset_batch = partial(diverse_batch_kmeans, n_instances=BATCH_SIZE)
+
+# Testing the cold-start
+learner = ActiveLearner(
+    estimator=KNeighborsClassifier(n_neighbors=3),
+    query_strategy=preset_batch
+)
+cold_start_idx, cold_start_inst = learner.query(X_raw)
+learner.teach(X_raw[cold_start_idx], y_raw[cold_start_idx])
+
+# Specify our active learning model.
+learner = ActiveLearner(
+    estimator=KNeighborsClassifier(n_neighbors=3),
+    X_training=X_train,
+    y_training=y_train,
+    query_strategy=preset_batch
+)
+
+predictions = learner.predict(X_raw)
+
+# Record our learner's score on the raw data.
+unqueried_score = learner.score(X_raw, y_raw)
+
+# Pool-based sampling
+N_RAW_SAMPLES = 20
+N_QUERIES = N_RAW_SAMPLES // BATCH_SIZE
+
+for index in range(N_QUERIES):
+    query_index, query_instance = learner.query(X_pool)
+
+    # Teach our ActiveLearner model the record it has requested.
+    X, y = X_pool[query_index], y_pool[query_index]
+    learner.teach(X=X, y=y)
+
+    # Remove the queried instance from the unlabeled pool.
+    X_pool = np.delete(X_pool, query_index, axis=0)
+    y_pool = np.delete(y_pool, query_index)
+
+    # Calculate and report our model's accuracy.
+    model_accuracy = learner.score(X_raw, y_raw)
+
+predictions = learner.predict(X_raw)


### PR DESCRIPTION
This is a PR that implements a new batch active learning query strategy (as mentioned in #119). [Diverse Mini-batch Active Learning](https://arxiv.org/abs/1901.05954) attempts to take into account both informativeness and diversity when selecting a batch of new examples to be labeled.

I'm not sure if there's any additional documentation you'd like to have added around this, so just let me know!