### PR TITLE
Proof of concept for allowing non-sklearn estimators

### DIFF
--- a/modAL/models/learners.py
+++ b/modAL/models/learners.py
@@ -5,7 +5,18 @@ from typing import Callable, Optional, Tuple, List, Any
 from sklearn.base import BaseEstimator
 from sklearn.metrics import accuracy_score
 
-from modAL.models.base import BaseLearner, BaseCommittee
+from modAL.models.base import (
+    BaseLearner,
+    BaseCommittee,
+    FitFunction,
+    PredictFunction,
+    PredictProbaFunction,
+    ScoreFunction,
+    SKLearnFitFunction,
+    SKLearnPredictFunction,
+    SKLearnPredictProbaFunction,
+    SKLearnScoreFunction
+)
 from modAL.utils.validation import check_class_labels, check_class_proba
 from modAL.utils.data import modALinput, retrieve_rows
 from modAL.uncertainty import uncertainty_sampling
@@ -69,6 +80,11 @@ class ActiveLearner(BaseLearner):
         ... )
     """
 
+    fit_func: FitFunction = SKLearnFitFunction()
+    predict_func: PredictFunction = SKLearnPredictFunction()
+    predict_proba_func: PredictProbaFunction = SKLearnPredictProbaFunction()
+    score_func: ScoreFunction = SKLearnScoreFunction()
+
     def __init__(self,
                  estimator: BaseEstimator,
                  query_strategy: Callable = uncertainty_sampling,
@@ -76,10 +92,17 @@ class ActiveLearner(BaseLearner):
                  y_training: Optional[modALinput] = None,
                  bootstrap_init: bool = False,
                  on_transformed: bool = False,
+                 force_all_finite: bool = True,
+                 fit_func: FitFunction = SKLearnFitFunction(),
+                 predict_func: PredictFunction = SKLearnPredictFunction(),
+                 predict_proba_func: PredictProbaFunction = SKLearnPredictProbaFunction(),
+                 score_func: ScoreFunction = SKLearnScoreFunction(),
                  **fit_kwargs
                  ) -> None:
         super().__init__(estimator, query_strategy,
-                         X_training, y_training, bootstrap_init, on_transformed, **fit_kwargs)
+                         X_training, y_training, bootstrap_init, on_transformed, force_all_finite,
+                         fit_func, predict_func, predict_proba_func, score_func,
+                         **fit_kwargs)
 
     def teach(self, X: modALinput, y: modALinput, bootstrap: bool = False, only_new: bool = False, **fit_kwargs) -> None:
         """
@@ -174,6 +197,12 @@ class BayesianOptimizer(BaseLearner):
         ...         query_idx, query_inst = optimizer.query(X)
         ...         optimizer.teach(X[query_idx].reshape(1, -1), y[query_idx].reshape(1, -1))
     """
+
+    fit_func: FitFunction = SKLearnFitFunction()
+    predict_func: PredictFunction = SKLearnPredictFunction()
+    predict_proba_func: PredictProbaFunction = SKLearnPredictProbaFunction()
+    score_func: ScoreFunction = SKLearnScoreFunction()
+
     def __init__(self,
                  estimator: BaseEstimator,
                  query_strategy: Callable = max_EI,
@@ -181,6 +210,10 @@ class BayesianOptimizer(BaseLearner):
                  y_training: Optional[modALinput] = None,
                  bootstrap_init: bool = False,
                  on_transformed: bool = False,
+                 fit_func: FitFunction = SKLearnFitFunction(),
+                 predict_func: PredictFunction = SKLearnPredictFunction(),
+                 predict_proba_func: PredictProbaFunction = SKLearnPredictProbaFunction(),
+                 score_func: ScoreFunction = SKLearnScoreFunction(),
                  **fit_kwargs) -> None:
         super(BayesianOptimizer, self).__init__(estimator, query_strategy,
                                                 X_training, y_training, bootstrap_init, on_transformed, **fit_kwargs)

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='modAL',
-    version='0.4.0',
+    version='0.4.1',
     author='Tivadar Danka',
     author_email='85a5187a@opayq.com',
     description='A modular active learning framework for Python3',

--- a/tests/example_tests/active_regression.py
+++ b/tests/example_tests/active_regression.py
@@ -27,7 +27,7 @@ kernel = RBF(length_scale=1.0, length_scale_bounds=(1e-2, 1e3)) \
 regressor = ActiveLearner(
     estimator=GaussianProcessRegressor(kernel=kernel),
     query_strategy=max_std_sampling,
-    X_training=X_initial.reshape(-1, 1), y_training=y_initial.reshape(-1, 1)
+    X_training=X_initial.reshape(-1, 1), y_training=y_initial.reshape(-1, 1),
 )
 
 # active learning


### PR DESCRIPTION
Not sure if there is any desire for this feature, but in this PR I have sketched out a way to use virtually any estimator type with the `ActiveLearner` and `BayesianOptimizer` classes.

### Motivation

Allow us to use other training and inference facilities, such as HuggingFace models that are trained using the `Trainer` class, use AWS SageMaker `Estimators`, etc. With this added flexibility, the training and inference does not need to even run on the same hardware as the `modAL` code. This brings the suite of sampling methods here to many new applications, particularly resource-intensive deep learning models that typically don't fit that great under the `sklearn` interface.

### Implementation

Rather than call the classic `sklearn` estimator functions such as `fit`, `predict`, `predict_proba`, and `score`, this PR adds a layer of callables that can be overridden: `fit_func`, `predict_func`, `predict_proba_func`, and `score_func`.

```python
    def __init__(self,
                 estimator: BaseEstimator,
                 query_strategy: Callable = uncertainty_sampling,
                 X_training: Optional[modALinput] = None,
                 y_training: Optional[modALinput] = None,
                 bootstrap_init: bool = False,
                 on_transformed: bool = False,
                 force_all_finite: bool = True,
                 fit_func: FitFunction = SKLearnFitFunction(),
                 predict_func: PredictFunction = SKLearnPredictFunction(),
                 predict_proba_func: PredictProbaFunction = SKLearnPredictProbaFunction(),
                 score_func: ScoreFunction = SKLearnScoreFunction(),
                 **fit_kwargs
                 ) -> None:
```

I added SKLearn implementations of each by default (included their corresponding `Protocol` classes as well). Here's how `fit` works:

```python
class FitFunction(Protocol):
    def __call__(self, estimator: GenericEstimator, X, y, **kwargs) -> GenericEstimator:
        raise NotImplementedError
# ...
class SKLearnFitFunction(FitFunction):
    def __call__(self, estimator: BaseEstimator, X, y, **kwargs) -> BaseEstimator:
        return estimator.fit(X=X, y=y, **kwargs)
```

I'll also note that the changes in this PR don't break any of the existing tests.

### Usage

When using [SageMaker](https://sagemaker.readthedocs.io/en/stable/), we might implement `fit` and `predict_proba` in this manner:

```python
class CustomEstimator:
    hf_predictor: Union[HuggingFacePredictor, Predictor]
    hf_estimator: HuggingFace

    def __init__(self, hf_predictor: HuggingFacePredictor, hf_estimator: HuggingFace):
        self.hf_predictor = hf_predictor
        self.hf_estimator = hf_estimator

class CustomFitFunction(FitFunction):
    def __call__(self, estimator: CustomEstimator, X, y, **kwargs) -> CustomEstimator:
        # notice we don't use `y` -- the label is baked into the HuggingFace Dataset
        return estimator.hf_estimator.fit(X=X, **kwargs)

class CustomPredictProbaFunction(PredictProbaFunction):
    @staticmethod
    def hf_prediction_to_proba(predictions: Union[List[Dict], object],
                               positive_class_label: str = 'LABEL_1',
                               negative_class_label: str = 'LABEL_0') -> np.array:
        label_key: str = 'label'
        score_key: str = 'score'
        p = []
        for prediction in predictions:
            if positive_class_label == prediction[label_key]:
                score = prediction[score_key]
                p.append([score, 1.0 - score])
            if negative_class_label == prediction[label_key]:
                score = prediction[score_key]
                p.append([1.0 - score, score])
        return np.array(p)

    def __call__(self, estimator: CustomEstimator, X, **kwargs) -> np.array:
        return self.hf_prediction_to_proba(
            predictions=estimator.hf_predictor.predict(dict(inputs=X))
        )

estimator = CustomEstimator(hf_predictor=hf_predictor, hf_estimator=hf_estimator)

learner = ActiveLearner(
    estimator=estimator,
    fit_func=CustomFitFunction(),
    predict_proba_func=CustomPredictProbaFunction(),
    X_training=train_dataset # standard HuggingFace Dataset instead of your typical types for `X` in `sklearn`
)
```

If you've made it this far, I'd ask that you forgive the clunkiness. This was a rough sketch of an idea I wanted to get written down before I forgot it. Anyways, would love some feedback, and if you think this PR is worth finishing, let me know. I can say for me, this would unlock a lot of really useful applications.
