### PR TITLE
Correcting float format in p_vote set

### DIFF
--- a/docs/source/content/query_strategies/Disagreement-sampling.rst
+++ b/docs/source/content/query_strategies/Disagreement-sampling.rst
@@ -32,7 +32,7 @@ Each instance has a corresponding probability distribution to it: the distributi
     >>> p_vote
     ... [[0.6666, 0.3333, 0.0   ]
     ...  [0.0   , 0.6666, 0.3333]
-    ...  [0.3333, 0,3333, 0,3333]
+    ...  [0.3333, 0.3333, 0.3333]
     ...  [0.0   , 0.0   , 1.0   ]
     ...  [0.0   , 0.3333, 0.6666]]
 


### PR DESCRIPTION
Commas were used instead of periods in 2 float values.