### PR TITLE
fix: make vstack correctly handle stacking dataframes and series

### DIFF
--- a/modAL/expected_error.py
+++ b/modAL/expected_error.py
@@ -16,7 +16,7 @@ from modAL.utils.selection import multi_argmin, shuffled_argmin
 
 
 def expected_error_reduction(learner: ActiveLearner, X: modALinput, loss: str = 'binary',
-                             p_subsample: np.float = 1.0, n_instances: int = 1,
+                             p_subsample: float = 1.0, n_instances: int = 1,
                              random_tie_break: bool = False) -> np.ndarray:
     """
     Expected error reduction query strategy.

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,7 +1,8 @@
-numpy==1.20.0
+numpy
 scipy
 scikit-learn
 ipykernel
 nbsphinx
 pandas
 skorch
+torch


### PR DESCRIPTION
Fixed the logic in hstack and vstack. This was causing tests to fail, as well as causing errors in a downstream project of mine.

Tests are now passing.

Not sure why numpy was recently pinned to an old version, but my dependency resolver couldn't find a solution (with Python 3,11) so I dropped it.