### PR TITLE
Fix unsafely broad except clauses

### DIFF
--- a/modAL/expected_error.py
+++ b/modAL/expected_error.py
@@ -16,7 +16,7 @@ from modAL.utils.selection import multi_argmin, shuffled_argmin
 
 
 def expected_error_reduction(learner: ActiveLearner, X: modALinput, loss: str = 'binary',
-                             p_subsample: np.float = 1.0, n_instances: int = 1,
+                             p_subsample: float = 1.0, n_instances: int = 1,
                              random_tie_break: bool = False) -> np.ndarray:
     """
     Expected error reduction query strategy.

--- a/modAL/models/base.py
+++ b/modAL/models/base.py
@@ -171,14 +171,13 @@ class BaseLearner(ABC, BaseEstimator):
             query_metrics: returns also the corresponding metrics, if return_metrics == True
         """
 
-        try:
-            query_result, query_metrics = self.query_strategy(
-                self, X_pool, *query_args, **query_kwargs)
-
-        except:
+        _query_strategy_result = self.query_strategy(
+            self, X_pool, *query_args, **query_kwargs)
+        if isinstance(_query_strategy_result, tuple) and len(_query_strategy_result) == 2:
+            query_result, query_metrics = _query_strategy_result
+        else:
+            query_result = _query_strategy_result
             query_metrics = None
-            query_result = self.query_strategy(
-                self, X_pool, *query_args, **query_kwargs)
 
         if return_metrics:
             if query_metrics is None: 
@@ -313,14 +312,13 @@ class BaseCommittee(ABC, BaseEstimator):
             query_metrics: returns also the corresponding metrics, if return_metrics == True
         """
 
-        try:
-            query_result, query_metrics = self.query_strategy(
-                self, X_pool, *query_args, **query_kwargs)
-
-        except:
+        _query_strategy_result = self.query_strategy(
+            self, X_pool, *query_args, **query_kwargs)
+        if isinstance(_query_strategy_result, tuple) and len(_query_strategy_result) == 2:
+            query_result, query_metrics = _query_strategy_result
+        else:
+            query_result = _query_strategy_result
             query_metrics = None
-            query_result = self.query_strategy(
-                self, X_pool, *query_args, **query_kwargs)
 
         if return_metrics:
             if query_metrics is None: 

--- a/rtd_requirements.txt
+++ b/rtd_requirements.txt
@@ -1,7 +1,8 @@
-numpy==1.20.0
+numpy
 scipy
 scikit-learn
 ipykernel
 nbsphinx
 pandas
 skorch
+torch

--- a/tests/core_tests.py
+++ b/tests/core_tests.py
@@ -115,11 +115,8 @@ class TestUtils(unittest.TestCase):
                     else:
                         true_result = n_functions*np.ones(shape=(n_samples, 1))
 
-                    try:
-                        np.testing.assert_almost_equal(
-                            linear_combination(X_in), true_result)
-                    except:
-                        linear_combination(X_in)
+                    np.testing.assert_almost_equal(
+                        linear_combination(X_in), true_result)
 
     def test_product(self):
         for n_dim in range(1, 5):
@@ -476,15 +473,11 @@ class TestDisagreements(unittest.TestCase):
 
                     true_KL_disagreement = np.zeros(shape=(n_samples, ))
 
-                    try:
-                        np.testing.assert_array_almost_equal(
-                            true_KL_disagreement,
-                            modAL.disagreement.KL_max_disagreement(
-                                committee, np.random.rand(n_samples, 1))
-                        )
-                    except:
+                    np.testing.assert_array_almost_equal(
+                        true_KL_disagreement,
                         modAL.disagreement.KL_max_disagreement(
                             committee, np.random.rand(n_samples, 1))
+                    )
 
                     # 2. unfitted committee
                     committee = mock.MockCommittee(fitted=False)


### PR DESCRIPTION
Includes #172 

It is poor practice to use unrestricted except clauses. This has resulted in multiple errors going unnoticed. I have removed these clauses and replaced with more specific (and therefore safer) logic.

Tests pass.